### PR TITLE
update gitignore to include package-lock and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 .env
+config/config.json


### PR DESCRIPTION
What was changed:
I updated the gitignore just in case you don't have the version that ignores the package-lock and the config file, you will now.

TO TEST:
Nope.