### PR TITLE
added delete payment feature with panoid true save payment in db

### DIFF
--- a/controllers/paymentCtrl.js
+++ b/controllers/paymentCtrl.js
@@ -27,3 +27,15 @@ module.exports.addPayment = (req, res, next) => {
     res.status(200).json(err);
   })
 };
+
+module.exports.destroyPayment = (req, res, next) => {
+  const { Payment_Type } = req.app.get('models');
+         Payment_Type.destroy({
+          where: {
+            id: req.params.id,
+          }
+        })
+        .then((data) => {
+          res.redirect(`/user/${req.user.id}`);
+        })
+};

--- a/models/payment_type.js
+++ b/models/payment_type.js
@@ -7,7 +7,7 @@ module.exports = (sequelize, DataTypes) => {
     name: DataTypes.STRING,
     account_number: DataTypes.INTEGER,
     user_id: DataTypes.INTEGER
-  }, {timestamps: false});
+  }, {timestamps: true, paranoid: true});
   
   // associates payment type with order and user since payment type has many and belongs to orders and users
   Payment_Type.associate = (models) => {

--- a/routes/paymentRoute.js
+++ b/routes/paymentRoute.js
@@ -5,11 +5,13 @@ const router = Router();
 
 const {
     addPayment,
-    displayAddPayment
+    displayAddPayment,
+    destroyPayment
   } = require('../controllers/paymentCtrl.js');
 
 router.get('/payment', displayAddPayment);
 router.post('/payment', isLoggedIn, addPayment);
+router.get('/deletePayment/:id', destroyPayment);
 
 
 function isLoggedIn(req, res, next) {

--- a/views/userAcctSettings.pug
+++ b/views/userAcctSettings.pug
@@ -10,6 +10,7 @@ block content
     h4 Payment information:
       each payment in userPmt
         p #{payment.name}:  #{payment.account_number}
+        a(href="/deletePayment/"+ payment.id) Delete Payment
 
     h3 Your orders: 
       each order in userOrders


### PR DESCRIPTION
Changed:
-added ability to delete user payments
- paranoid true is being used so even thou you delete the payment it still saves it in the DB and adds a deletedAt column so the payment can still be used in an ongoing order.

Because:
-feature ticket 8 requires it

To test:
(steps to test -- include everything!)
1.go to your account setting add payment if none exist and click delete link. The payment will be removed from your account 
2. In PSQL select * from "Payment_Types"; and the payment you deleted will still be there but be timestamped with the deletedAt date.
